### PR TITLE
Debugging idtoken transmission

### DIFF
--- a/synapse/config/logger.py
+++ b/synapse/config/logger.py
@@ -329,14 +329,7 @@ def setup_logging(
         logBeginner: The Twisted logBeginner to use.
 
     """
-    logger = logging.getLogger(__name__)
-    logging.warning("=== LOG OUTPUT: A1 ===")
-    logger.warning("=== LOG OUTPUT: B1 ===")
-
     from twisted.internet import reactor
-
-    logging.warning("=== LOG OUTPUT: A2 ===")
-    logger.warning("=== LOG OUTPUT: B2 ===")
 
     log_config_path = (
         config.worker.worker_log_config
@@ -344,25 +337,15 @@ def setup_logging(
         else config.logging.log_config
     )
 
-    logging.warning("=== LOG OUTPUT: A3 ===")
-    logger.warning("=== LOG OUTPUT: B3 ===")
-
     # Perform one-time logging configuration.
-    # _setup_stdlib_logging(config, log_config_path, logBeginner=logBeginner)
 
-    logging.warning("=== LOG OUTPUT: A4 ===")
-    logger.warning("=== LOG OUTPUT: B4 ===")
+    # workaround for AWS ECS logging driver
+    # _setup_stdlib_logging(config, log_config_path, logBeginner=logBeginner)
 
     # Add a SIGHUP handler to reload the logging configuration, if one is available.
     from synapse.app import _base as appbase
 
-    logging.warning("=== LOG OUTPUT: A5 ===")
-    logger.warning("=== LOG OUTPUT: B5 ===")
-
     appbase.register_sighup(_reload_logging_config, log_config_path)
-
-    logging.warning("=== LOG OUTPUT: A6 ===")
-    logger.warning("=== LOG OUTPUT: B6 ===")
 
     # Log immediately so we can grep backwards.
     logging.warning("***** STARTING SERVER *****")

--- a/synapse/rest/client/vp_request.py
+++ b/synapse/rest/client/vp_request.py
@@ -53,7 +53,7 @@ class HandleVpRequest(RestServlet):
             "client_id_scheme": "x509_san_dns",
             "response_uri": client_id,
             "nonce": ro_nonce,
-            "response_mode": "direct_post",
+            "response_mode": "post",
             "response_type": "vp_token",
             "presentation_definition": {
                 "id": sid,


### PR DESCRIPTION
- ログ設定のデバッグのために挿入した出力は不要となったため削除します。
- SIOPv2リクエストの`response_mode`の値は、[9.2](https://openid.net/specs/openid-connect-self-issued-v2-1_0.html#section-9.2)の例に従うようにしました。