### PR TITLE
Modified to hide the confirmation message in case of SIOPv2.

### DIFF
--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -1869,6 +1869,7 @@ class AuthHandler:
             new_user=new_user,
             user_id=registered_user_id,
             user_profile=user_profile_data,
+            is_siopv2=siopv2_sid is not None,
         )
         respond_with_html(request, 200, html)
 

--- a/synapse/res/templates/sso_redirect_confirm.html
+++ b/synapse/res/templates/sso_redirect_confirm.html
@@ -31,7 +31,9 @@
 </header>
 <main>
     {% include "sso_partial_profile.html" %}
-    <p class="confirm-trust">Continuing will grant <strong>{{ display_url }}</strong> access to your account.</p>
+    {% if not is_siopv2 %}
+        <p class="confirm-trust">Continuing will grant <strong>{{ display_url }}</strong> access to your account.</p>
+    {% endif %}
     <a href="{{ redirect_url }}" class="primary-button">Continue</a>
 </main>
 {% include "sso_footer.html" without context %}


### PR DESCRIPTION
- callback先がダミーのURLであり、表示する意味がない。
- メッセージを非表示にする。