### PR TITLE
Fix client_id as we did for SIOPv2

### DIFF
--- a/synapse/handlers/vp_handler.py
+++ b/synapse/handlers/vp_handler.py
@@ -416,6 +416,9 @@ class VerifiablePresentationHandler:
         expected_aud = urllib.parse.urljoin(
             self.base_url, "/".join(["/_matrix/client/v3/vp_response", sid])
         )
+        ### WIP
+        expected_aud = "https://ownd-project.com:8008/"
+
         expected_nonce = await self._store.lookup_vp_ro_nonce(sid)
         raw_token_value = vp_token[0]
         vp_type = await self._store.lookup_vp_type(sid)

--- a/synapse/rest/client/vp.py
+++ b/synapse/rest/client/vp.py
@@ -41,6 +41,8 @@ class HandleVpInitiation(RestServlet):
         client_id = urllib.parse.urljoin(
             self.base_url, "/".join(["/_matrix/client/v3/vp_response", sid])
         )
+        ### WIP
+        client_id = "https://ownd-project.com:8008/"
 
         request_uri = urllib.parse.urljoin(
             self.base_url, "/".join(["/_matrix/client/v3/vp_request", sid])

--- a/synapse/rest/client/vp_request.py
+++ b/synapse/rest/client/vp_request.py
@@ -49,7 +49,9 @@ class HandleVpRequest(RestServlet):
         input_descriptors, requirements = make_required_descriptors(vp_type)
 
         payload = {
-            "client_id": client_id,
+            ### WIP
+            "client_id": "https://ownd-project.com:8008/",
+
             "client_id_scheme": "x509_san_dns",
             "response_uri": client_id,
             "nonce": ro_nonce,


### PR DESCRIPTION
- client_idに記載するURLをWallet側にて、RPのIDとして使いたいことから固定の文字列とする。
- SIOPv2でも同様のことを行なっている。
  -  https://github.com/datasign-inc/synapse/pull/23