### PR TITLE
Workaround: The combination of UIA and SIOPv2 has not been implemente…

### DIFF
--- a/synapse/rest/client/account.py
+++ b/synapse/rest/client/account.py
@@ -307,6 +307,7 @@ class DeactivateAccountRestServlet(RestServlet):
                 request,
                 body.dict(exclude_unset=True),
                 "deactivate your account",
+                can_skip_ui_auth=True # Temporary solution until UIA and SIOPv2 can be used together.
             )
 
         result = await self._deactivate_account_handler.deactivate_account(

--- a/synapse/rest/client/keys.py
+++ b/synapse/rest/client/keys.py
@@ -411,7 +411,7 @@ class SigningKeyUploadServlet(RestServlet):
                     body,
                     "reset the device signing key on your account",
                     # Do not allow skipping of UIA auth.
-                    can_skip_ui_auth=False,
+                    can_skip_ui_auth=True, # Temporary solution until UIA and SIOPv2 can be used together.
                 )
             # Otherwise we don't require UIA since we are setting up cross signing for first time
 


### PR DESCRIPTION
- MatrixのUIA(User Interactive Authentication)とSIOPv2の組み合わせを適切に実装できていない状況。
- 一時的にUIAが不要となるように修正する。
